### PR TITLE
adding gemma download to the landing page

### DIFF
--- a/lib/data/downloader_datasource.dart
+++ b/lib/data/downloader_datasource.dart
@@ -64,7 +64,6 @@ class GemmaDownloaderDataSource {
 
   /// Downloads the model file and tracks progress.
   Future<void> downloadModel({
-    required String token,
     required Function(double) onProgress,
   }) async {
     http.StreamedResponse? response;
@@ -81,8 +80,8 @@ class GemmaDownloaderDataSource {
       }
 
       final request = http.Request('GET', Uri.parse(model.modelUrl));
-      if (token.isNotEmpty) {
-        request.headers['Authorization'] = 'Bearer $token';
+      if (accessToken.isNotEmpty) {
+        request.headers['Authorization'] = 'Bearer $accessToken';
       }
 
       if (downloadedBytes > 0) {

--- a/lib/presentation/pages/landing_page.dart
+++ b/lib/presentation/pages/landing_page.dart
@@ -2,6 +2,7 @@ import 'package:emergency_buddy/core/utils/constants.dart';
 import 'package:emergency_buddy/presentation/widgets/first_aid/first_aid_listing.dart';
 import 'package:emergency_buddy/presentation/widgets/footer_section/footer_section_sliver_mobile.dart';
 import 'package:emergency_buddy/presentation/widgets/footer_section/footer_section_sliver_web.dart';
+import 'package:emergency_buddy/presentation/widgets/gemma/gemma_loading_widget.dart';
 import 'package:emergency_buddy/presentation/widgets/header_section/header_section_sliver_mobile.dart';
 import 'package:emergency_buddy/presentation/widgets/header_section/header_section_sliver_web.dart';
 import 'package:emergency_buddy/presentation/widgets/hospitals/hospital_listing.dart';
@@ -56,6 +57,13 @@ class _LandingPageSliverState extends State<LandingPageSliver> {
                         : SliverTopBarMobile(title: widget.title),
                   ),
                 ),
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding: EdgeInsets.all(UIConstants.mediumSize),
+                    child: GemmaLoadingWidget(),
+                  ),
+                ),
+
                 SliverToBoxAdapter(
                   child: Padding(
                     padding: EdgeInsets.all(UIConstants.mediumSize),

--- a/lib/presentation/widgets/gemma/gemma_loading_widget.dart
+++ b/lib/presentation/widgets/gemma/gemma_loading_widget.dart
@@ -1,0 +1,131 @@
+import 'dart:io';
+import 'package:device_info_plus/device_info_plus.dart';
+import 'package:emergency_buddy/data/downloader_datasource.dart';
+import 'package:emergency_buddy/domain/entities/download_model.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+class GemmaLoadingWidget extends StatefulWidget {
+  const GemmaLoadingWidget({super.key});
+
+  @override
+  State<GemmaLoadingWidget> createState() => _GemmaLoadingWidgetState();
+}
+
+class _GemmaLoadingWidgetState extends State<GemmaLoadingWidget> {
+  bool _isModelLoading = true;
+  bool _isLowRamDevice = false;
+  late final DeviceInfoPlugin deviceInfo;
+  late final AndroidDeviceInfo androidInfo;
+  late final IosDeviceInfo iosInfo;
+  late final GemmaDownloaderDataSource _downloaderDataSource;
+  final ValueNotifier<String> _loadingMessage =
+  ValueNotifier('Initializing, loading Gemma...');
+
+  Future<bool> loadModel() async {
+    if (kIsWeb) {
+      // Is already loaded as using gemma from assets
+      _loadingMessage.value = 'Loading Gemma model for web...';
+      setState(() {
+        _isModelLoading = false;
+      });
+      return true;
+    }
+    if (_isLowRamDevice) {
+      _downloaderDataSource = GemmaDownloaderDataSource(
+        model: DownloadModel(
+          modelUrl:
+          'https://huggingface.co/litert-community/Gemma3-1B-IT/resolve/main/Gemma3-1B-IT_multi-prefill-seq_q4_ekv2048.task',
+          modelFilename: 'Gemma3-1B-IT_multi-prefill-seq_q4_ekv2048.task',
+        ),
+      );
+    } else {
+      _downloaderDataSource = GemmaDownloaderDataSource(
+        model: DownloadModel(
+          modelUrl:
+          'https://huggingface.co/google/gemma-3n-E2B-it-litert-preview/resolve/main/gemma-3n-E2B-it-int4.task',
+          modelFilename: 'gemma-3n-E2B-it-int4.task',
+        ),
+      );
+    }
+
+    // Check model existence first
+    bool exists = await _downloaderDataSource.checkModelExistence();
+    if (exists) {
+      _loadingMessage.value = 'Model already exists, loading...';
+      setState(() {
+        _isModelLoading = false;
+      });
+      return true;
+    }
+
+    await _downloaderDataSource.downloadModel(
+      onProgress: (progress) {
+        _loadingMessage.value =
+        'Downloading model: ${(progress * 100).toStringAsFixed(1)}%';
+      },
+    );
+
+    exists = await _downloaderDataSource.checkModelExistence();
+    if (exists) {
+      setState(() {
+        _isModelLoading = false;
+      });
+    } else {
+      _loadingMessage.value = 'Model already exists, loading...';
+    }
+    return exists;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    deviceInfo = DeviceInfoPlugin();
+    //check if RAM is less than 8GB in which case we use the smaller model
+    if (kIsWeb) {
+      //loading straight away as Platform is not available on web.
+      _isLowRamDevice = false;
+      loadModel();
+    } else if (Platform.isIOS) {
+      deviceInfo.iosInfo.then((info) {
+        iosInfo = info;
+        _isLowRamDevice = (info.physicalRamSize < 6 * 1024);
+        loadModel(); // Check if available RAM is less than 6GB
+      });
+    } else if (Platform.isAndroid) {
+      deviceInfo.androidInfo.then((info) {
+        androidInfo = info;
+        _isLowRamDevice = info.isLowRamDevice;
+        loadModel();
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: _isModelLoading
+          ? Container(
+        padding: const EdgeInsets.all(16.0),
+        decoration: BoxDecoration(
+          color: Colors.yellow,
+          borderRadius: BorderRadius.circular(8.0),
+        ),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            CircularProgressIndicator(),
+            SizedBox(height: 16),
+            ValueListenableBuilder<String>(
+              valueListenable: _loadingMessage,
+              builder: (context, value, child) {
+                return Text(value);
+              },
+            ),
+          ],
+        ),
+      )
+          : SizedBox.shrink(),
+    );
+  }
+}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,6 +6,7 @@ import FlutterMacOS
 import Foundation
 
 import connectivity_plus
+import device_info_plus
 import file_selector_macos
 import geolocator_apple
 import network_info_plus
@@ -16,6 +17,7 @@ import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
+  DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
   NetworkInfoPlusPlugin.register(with: registry.registrar(forPlugin: "NetworkInfoPlusPlugin"))

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   freezed: ^3.2.0
   freezed_annotation: ^3.1.0
   fuzzywuzzy: ^1.2.0
+  device_info_plus: ^11.5.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- determines if low ram device then it downloads the 1B model
- otherwise the E2B model but it takes very long, need to discuss if we should have the 1B model as backup

for each personal account:
- web will access assets only so the model needs to be copied into the assets folder
- hugging face token needs to be added to downloader_datasource.dart